### PR TITLE
mcrypt_create_iv Deprecated

### DIFF
--- a/EncryptorClass.php
+++ b/EncryptorClass.php
@@ -26,7 +26,7 @@ class Encryptor{
     }
     function saltor($rnds,$type) {
         
-        $rand_num = base64_encode(mcrypt_create_iv(22,MCRYPT_DEV_URANDOM));
+        $rand_num = base64_encode(random_bytes(22));
         
         if($type == "SHA256") {
             


### PR DESCRIPTION
As of PHP 7.1.0, mcrypt_create_iv has been deprecated and removed in PHP 7.2.0. So, I have used random_bytes instead as an alternative given at https://www.php.net/manual/en/function.mcrypt-create-iv.php. I hope this will help anyone using PHP 7.2 or higher.